### PR TITLE
Avoid when triggered by Dependabot (`triggering_actor` allows for manual run/re-run)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,11 @@ jobs:
   analyze_c_sharp:
     name: Analyze C#
     runs-on: windows-latest
+
+    ## Avoid when triggered by Dependabot (`triggering_actor` allows for manual run/re-run)
+    ## https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+
     permissions:
       actions: read
       contents: read
@@ -101,6 +106,11 @@ jobs:
   analyze_javascript:
     name: Analyze Javascript
     runs-on: ubuntu-latest
+
+    ## Avoid when triggered by Dependabot (`triggering_actor` allows for manual run/re-run)
+    ## https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Also, this StackOverflow answer:

> I guess there were many changes over the years and you can find outdated ways all over the web. The actual way is [documented in the Dependabot documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
> 
> ```yml
> if: ${{ github.actor != 'dependabot[bot]' }}
> ```
> 
> Note that nowadays you can also check the github.triggering_actor - if you want workflow to be skipped if Dependabot triggered it, but want to be able to manually trigger it on a PR that was opened by Dependabot

https://stackoverflow.com/a/71854535

